### PR TITLE
[MAN-1670]Update try-click

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject webdriver "0.14.1"
+(defproject webdriver "0.14.2"
   :description "A clojure selenium webdriver wrapper"
   :url "https://github.com/komcrad/webdriver"
   :license {:name "LGPL-3.0"

--- a/src/webdriver/core.clj
+++ b/src/webdriver/core.clj
@@ -2,7 +2,7 @@
   (:gen-class)
   (:import
     [java.util.concurrent TimeUnit] [org.openqa.selenium.remote RemoteWebDriver]
-    [org.openqa.selenium WebElement]
+    [org.openqa.selenium WebElement WebDriverException]
     [org.openqa.selenium.support.ui WebDriverWait ExpectedConditions])
   (:require [webdriver.driver-manager :as dm]
             [webdriver.screen :as scr]
@@ -509,7 +509,7 @@
   ([driver lookup-type lookup-string timeout]
    (wait-for
     #(try (click driver lookup-type lookup-string) true
-          (catch Exception e false))
+          (catch WebDriverException e false))
     (* 1000 timeout) 500))
   ([driver lookup-type lookup-string]
    (try-click driver lookup-type lookup-string 10)))


### PR DESCRIPTION
This fixes an issue where try-click since it caught all exceptions was preventing InterruptedException from being handled properly, this way we only catch the exceptions we expect to see.