### PR TITLE
[MAN-1713] Update documentation and version of chromedriver to 78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [0.14.3 2019-11-4]
+## Added
+- default driver is 78.0.3904.70
+
+## [0.14.2 2019-10-29]
+## Fixed
+- no longer catch all exceptions in try-click, it was breaking thread interrupts
+
 ## [0.14.1 2019-08-14]
 ## Fixed
 - added --no-sandbox to chrome options which fixes issues with running chromium in docker

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ core.clj contains functions to handle common browser tasks. You can either read 
 
 ## Building Docker image
 ```
-docker build --no-cache -t attackhelicopter/webdriver:0.11.0 -t attackhelicopter/webdriver:latest .
+docker build --no-cache -t attackhelicopter/webdriver:0.12.0 -t attackhelicopter/webdriver:latest .
 ```
 
 ## Running unit tests in docker image locally
@@ -105,6 +105,9 @@ lein test
 ```
 
 ## Tested versions of firefox and chrome
+- webdriver 0.14.3
+  - Firefox 68.0.1
+  - Chromium 78.0.3904.70
 - webdriver 0.14.0
   - Firefox 68.0.1
   - Chromium 76.0.3809.87

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject webdriver "0.14.2"
+(defproject webdriver "0.14.3"
   :description "A clojure selenium webdriver wrapper"
-  :url "https://github.com/komcrad/webdriver"
+  :url "https://github.com/wsbu/webdriver"
   :license {:name "LGPL-3.0"
             :url "https://www.gnu.org/licenses/lgpl-3.0.en.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]

--- a/src/webdriver/driver_manager.clj
+++ b/src/webdriver/driver_manager.clj
@@ -12,7 +12,7 @@
 			   LoggingPreferences LogType)
 			 (java.util.logging Level Logger)))
 
-(defonce latest-chrome-version "76.0.3809.68")
+(defonce latest-chrome-version "78.0.3904.70")
 (defonce latest-gecko-version "0.24.0")
 
 (defn- mkdownload-dir [m]


### PR DESCRIPTION
This updates the Chrome (or chromium) version used to version 78. Also updates documentation.